### PR TITLE
Pass the flag --no-codesign by default to iOS build

### DIFF
--- a/tasks/build/index.js
+++ b/tasks/build/index.js
@@ -91,6 +91,9 @@ function buildIpa(flutter, simulator, codesign, buildName, buildNumber, debugMod
         else if (codesign) {
             args.push("--codesign");
         }
+        else {
+            args.push("--no-codesign");
+        }
         if (buildName) {
             args.push("--build-name=" + buildName);
         }

--- a/tasks/build/index.ts
+++ b/tasks/build/index.ts
@@ -98,6 +98,9 @@ async function buildIpa(flutter: string, simulator?: boolean, codesign?: boolean
     else if (codesign) {
         args.push("--codesign");
     }
+    else {
+        args.push("--no-codesign");
+    }
 
     if (buildName) {
         args.push("--build-name=" + buildName);


### PR DESCRIPTION
We're using [fastlane](https://docs.fastlane.tools) with Flutter and the build instructions require us to pass the `--no-codesign` flag to [the iOS build](https://flutter.dev/docs/deployment/cd).

This was the best and least intrusive change I could make. Let me know your thoughts - would be great to get this through quickly if it's ok.