### PR TITLE
Publish the extension using Azure Pipelines

### DIFF
--- a/azure-pipelines-publish.yml
+++ b/azure-pipelines-publish.yml
@@ -11,6 +11,6 @@ steps:
     connectTo: 'VsTeam'
     connectedServiceName: 'Azure DevOps Marketplace'
     fileType: 'manifest'
-    publisherId: 'MichaelSoderman'
+    publisherId: 'aloisdeniel'
     extensionVisibility: 'public'
     extensionPricing: 'free'

--- a/azure-pipelines-publish.yml
+++ b/azure-pipelines-publish.yml
@@ -1,0 +1,16 @@
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- task: TfxInstaller@2
+  inputs:
+    version: 'v0.6.x'
+
+- task: PublishAzureDevOpsExtension@2
+  inputs:
+    connectTo: 'VsTeam'
+    connectedServiceName: 'Azure DevOps Marketplace'
+    fileType: 'manifest'
+    publisherId: 'MichaelSoderman'
+    extensionVisibility: 'public'
+    extensionPricing: 'free'


### PR DESCRIPTION
This pipeline will publish the extension to the marketplace.

1. The trigger should be specified.
1. The extension [Azure DevOps Extension Tasks](https://marketplace.visualstudio.com/items?itemName=ms-devlabs.vsts-developer-tools-build-tasks) must be installed.
1. A service connection must be added. I'm not sure what permissions the PAT needs.