### PR TITLE
Update Readme with correct commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,26 +20,27 @@ Add the tasks to your build definition.
 
 Installs the [Flutter SDK](https://flutter.io/sdk-archive/) onto the running agent if not already installed. Then uses it for following tasks.
 
-* Select the `channel`: `stable (default)`, `beta`, or `dev`.
-* Select the `version` of the SDK to install:  `latest (default)`, `custom`. If `custom` is specified, a `custom version` must be set.
-* _(Optional)_. Set the `custom version` (in a `<M>.<m>.<p>` semver format) if needed.
+* Select the `channel`: `stable` (default), `beta`, or `dev`.
+* Select the `version` of the SDK to install:  `latest` (default), `custom`. If `custom` is specified, a `customVersion` must be set.
+* _(Optional)_. Set the `customVersion` (in a `<M>.<m>.<p>` semver format) if needed.
 
 ### Build
 
 ![](images/step_build.png)
 
-Build the given mobile application project. You must call the `Flutter Install` task, set a `FlutterToolPath` environment variable, or use the optional Flutter SDK Path task entry that points to your `flutter/bin` folder before execution. All the application bundles are created into the `build/outputs` folder of your project.
+Build the given mobile application project. You must call the `Flutter Install` task or use the optional `flutterDirectory` task input that points to your `flutter/bin` folder before execution. All application bundles are created in the `build/outputs` folder of your project.
 
-* Select the `project source directory` (that contains to `pubspec.yaml` file).
-* Select the `target` platform: `Android (default)`, `iOS`, or `All` for both.
-* _(Optional)_. Set `flutter sdk path` if using a local agent with a pre-installed Flutter SDK, can specify the path to utilize it.  Otherwise use Flutter Install.
-* _(Optional)_. Set `package name` (like `1.2.3`) that will override the manifest's one.
-* _(Optional)_. Set `package number` (like `12`) that will override the manifest's one.
-* _(Optional)_. Set `build flavour` (like `development`) to specify a build flavour.  Must match Android Gradle flavor definition or XCode scheme.
-* _(Optional)_. Set `debug` if you wish to override the default release mode for the build.
-* __(Android)__._(Optional)_. Set `platform` for the Android target: `android-arm (default)`, `android-arm64`.
-* __(iOS)__._(Optional)_. Set `platform` for the iOS target: `device (default)`, `simulator`.
-* __(iOS)__._(Optional)_. Codesign the application bundle (only available on device builds, and activated by default). **Warning: you must install a valid certificate before build with the `Install an Apple Certificate`task**
+* Select the `projectDirectory` that contains the `pubspec.yaml` file.
+* Select the `target` platform. Options are: `apk` (default), `aab`, `ios`, `web` or `all` for both Android and iOS, but without Web.
+* _(Optional)_. Set `flutterDirectory` to set path to the Flutter SDK if you were not using `Flutter Install` task before this one
+* _(Optional)_. Set `buildName` (like `1.2.3`) that will override the manifest's one.
+* _(Optional)_. Set `buildNumber` (like `12`) that will override the manifest's one.
+* _(Optional)_. Set `buildFlavour` (like `development`) to specify a build flavour. Must match Android Gradle flavor definition or XCode scheme.
+* _(Optional)_. Set `debugMode` if you wish to override the default release mode for the build.
+* _(Optional)_. Set `entryPoint` to override the main entry point file of the application. Default is 'lib/main.dart'.
+* __(Android)__._(Optional)_. Set `apkTargetPlatform` for the Android platform architecture target: `android-arm` (default), `android-arm64`.
+* __(iOS)__._(Optional)_. Set `iosTargetPlatform` for the iOS target: `device` (default), `simulator`.
+* __(iOS)__._(Optional)_. Set `iosCodesign` to configure whenever the bundle odesign the application bundle (only available on device builds, and activated by default). **Warning: you must install a valid certificate before build with the `Install an Apple Certificate`task**
 
 ### Test
 
@@ -47,12 +48,11 @@ Build the given mobile application project. You must call the `Flutter Install` 
 
 Launch tests and publish a report as build test results.
 
-* Select the `project source directory` (that contains to `pubspec.yaml` file).
-* _(Optional)_. Set `test name` as a regular expression matching substrings of the names of tests to run.
-* _(Optional)_. Set `Test plain name` as a plain-text substring of the names of tests to run.
-* _(Optional)_. Set `Test plain name` as a plain-text substring of the names of tests to run.
-* _(Optional)_. Set `update goldens`: whether `matchesGoldenFile()` calls within your test methods should update the golden files rather than test for an existing match.
-* _(Optional)_. The number of `concurrent` test processes to run. (defaults to `6`)
+* Select the `projectDirectory` that contains to `pubspec.yaml` file.
+* _(Optional)_. Set `testName` as a regular expression matching substrings of the names of tests to run.
+* _(Optional)_. Set `testPlainName` as a plain-text substring of the names of tests to run.
+* _(Optional)_. Set `updateGoldens`: whether `matchesGoldenFile()` calls within your test methods should update the golden files rather than test for an existing match.
+* _(Optional)_. Set `concurrency` to specify the number of concurrent test processes to run. Default is `6`.
 
 ### command
 


### PR DESCRIPTION
This PR updates the README file to have real command names, so users can just copy the command name instead of trying to find it in the source code.

I went through the source code to pick proper names and options for these commands.

Also, added one command, which wasn't mentioned before, but exists in the source code.

P.S. Thanks for such a useful set of tasks 🚀 