### PR TITLE
Change Azure VM image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ variables:
 jobs:
   - job: Android
     pool:
-      vmImage: 'macOS-10.13'
+      vmImage: 'macOS-latest'
     steps:
     - task: FlutterInstall@0
     - task: FlutterBuild@0


### PR DESCRIPTION
Looks like the CI fails for quite some time already due to Azure dropping High Sierra from available VM images.

This is a small change to fix failing Azure pipeline builds by using the latest MacOS VM images.
