### PR TITLE
Added support for 'flutter build ipa'

### DIFF
--- a/tasks/build/index.js
+++ b/tasks/build/index.js
@@ -39,7 +39,13 @@ function main() {
         if (target === "all" || target === "ios") {
             let targetPlatform = task.getInput('iosTargetPlatform', false);
             let codesign = task.getBoolInput('iosCodesign', false);
-            yield buildIpa(flutterPath, targetPlatform == "simulator", codesign, buildName, buildNumber, debugMode, buildFlavour, entryPoint);
+            yield buildIos(flutterPath, targetPlatform == "simulator", codesign, buildName, buildNumber, debugMode, buildFlavour, entryPoint);
+        }
+        if (target === "all" || target === "ipa") {
+            let targetPlatform = task.getInput('iosTargetPlatform', false);
+            let codesign = task.getBoolInput('iosCodesign', false);
+            let exportOptionsPlist = task.getInput('iosExportOptionsPlist', false);
+            yield buildIpa(flutterPath, targetPlatform == "simulator", codesign, buildName, buildNumber, debugMode, buildFlavour, entryPoint, exportOptionsPlist);
         }
         if (target === "all" || target === "apk") {
             let targetPlatform = task.getInput('apkTargetPlatform', false);
@@ -111,7 +117,7 @@ function buildAab(flutter, buildName, buildNumber, debugMode, buildFlavour, entr
         }
     });
 }
-function buildIpa(flutter, simulator, codesign, buildName, buildNumber, debugMode, buildFlavour, entryPoint) {
+function buildIos(flutter, simulator, codesign, buildName, buildNumber, debugMode, buildFlavour, entryPoint) {
     return __awaiter(this, void 0, void 0, function* () {
         var args = [
             "build",
@@ -149,6 +155,50 @@ function buildIpa(flutter, simulator, codesign, buildName, buildNumber, debugMod
         var result = yield task.exec(flutter, args);
         if (result !== 0) {
             throw new Error("ios build failed");
+        }
+    });
+}
+function buildIpa(flutter, simulator, codesign, buildName, buildNumber, debugMode, buildFlavour, entryPoint, exportOptionsPlist) {
+    return __awaiter(this, void 0, void 0, function* () {
+        var args = [
+            "build",
+            "ipa"
+        ];
+        if (debugMode) {
+            args.push("--debug");
+        }
+        if (simulator) {
+            args.push("--simulator");
+            if (!debugMode) {
+                args.push("--debug"); // simulator can only be built in debug
+            }
+        }
+        else if (codesign) {
+            args.push("--codesign");
+        }
+        else {
+            args.push("--no-codesign");
+        }
+        if (buildName) {
+            args.push("--build-name=" + buildName);
+        }
+        if (buildNumber) {
+            args.push("--build-number=" + buildNumber);
+        }
+        if (entryPoint) {
+            args.push("--target=" + entryPoint);
+        }
+        if (exportOptionsPlist) {
+            args.push("--export-options-plist=" + exportOptionsPlist);
+        }
+        if (!simulator) {
+            if (buildFlavour) {
+                args.push("--flavor=" + buildFlavour);
+            }
+        }
+        var result = yield task.exec(flutter, args);
+        if (result !== 0) {
+            throw new Error("ipa build failed");
         }
     });
 }

--- a/tasks/build/task.json
+++ b/tasks/build/task.json
@@ -26,7 +26,8 @@
             "required": true,
             "options": {
                 "all": "All (except 'Web').",
-                "ios": "iOS",
+                "ios": "iOS (app)",
+                "ipa": "iOS (ipa)",
                 "apk": "Android (apk)",
                 "aab": "Android (aab)",
                 "web": "Web"
@@ -108,7 +109,20 @@
             "defaultValue": "device",
             "required": false,
             "helpMarkDown": "Sets the target iOS platform",
-            "visibleRule": "target = ios",
+            "visibleRule": "target = ios || target = ipa",
+            "options": {
+                "device": "Device",
+                "simulator": "Simulator"
+            }
+        },
+        {
+            "name": "iosExportOptionsPlist",
+            "type": "string",
+            "label": "Export options plist",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Sets the --export-options-plist",
+            "visibleRule": "target = ipa",
             "options": {
                 "device": "Device",
                 "simulator": "Simulator"
@@ -121,7 +135,7 @@
             "defaultValue": "true",
             "required": false,
             "helpMarkDown": "Indicates whether the application bundle should be codesigned. **Warning: you must install a valid certificate before build with the `Install an Apple Certificate`task**",
-            "visibleRule": "target = ios"
+            "visibleRule": "target = ios || target = ipa"
         }
     ],
     "execution": {


### PR DESCRIPTION
Added support for 'flutter build ipa' and for the extra argument '--export-options-plist'

The official documentation uses 'ipa' instead of 'ios'
https://flutter.dev/docs/deployment/ios#create-a-build-archive